### PR TITLE
Resolve method ambiguities

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
       # jf: reduce testing for lower carbon footprint
       # version: ['1.4', '1', 'nightly']
-        version: ['1.5', 'nightly']
+        version: ['1.6', 'nightly']
         os: [ubuntu-latest, windows-latest, macOS-latest]
       # fail-fast: true
     steps:
@@ -31,6 +31,6 @@ jobs:
 #     - name: "Cover"
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v1
-        if: ${{ matrix.version == '1.5' && matrix.os == 'ubuntu-latest' }}
+        if: ${{ matrix.version == '1.6' && matrix.os == 'ubuntu-latest' }}
         with:
           file: lcov.info

--- a/Project.toml
+++ b/Project.toml
@@ -11,4 +11,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 LinearMaps = "3"
-julia = "1.5"
+julia = "1.6"

--- a/src/LinearMapsAA.jl
+++ b/src/LinearMapsAA.jl
@@ -12,6 +12,7 @@ Indexer = AbstractVector{Int}
 
 include("types.jl")
 include("multiply.jl")
+include("ambiguity.jl")
 include("kron.jl")
 include("cat.jl")
 include("getindex.jl")

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -1,0 +1,7 @@
+#=
+ambiguity.jl
+Avoiding method ambiguities
+This may be a bit of a whack-a-mole™ exercise...
+=#
+
+Base.(*)(A::LinearAlgebra.AbstractTriangular, B::LinearMapAM) = M_AM(A, B)

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -8,7 +8,6 @@ import LinearAlgebra
 
 const Trans = LinearAlgebra.Transpose{<: Any, <: LinearAlgebra.RealHermSymComplexSym}
 const Adjoi = LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.RealHermSymComplexHerm}
-const Given = LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.AbstractRotation}
 
 Base.:(*)(A::LinearMapAM, D::LinearAlgebra.Diagonal) = AM_M(A, D)
 Base.:(*)(D::LinearAlgebra.Diagonal, B::LinearMapAM,) = M_AM(D, B)
@@ -22,8 +21,11 @@ Base.:(*)(A::Trans, B::LinearMapAM) = M_AM(A, B)
 Base.:(*)(A::LinearMapAM, B::Adjoi) = AM_M(A, B)
 Base.:(*)(A::Adjoi, B::LinearMapAM) = M_AM(A, B)
 
-Base.:(*)(A::LinearMapAM, B::Given) = AM_M(A, B)
-Base.:(*)(A::Given, B::LinearMapAM) = M_AM(A, B)
+# see https://github.com/Jutho/LinearMaps.jl/issues/118
+Base.:(*)(A::LinearMapAM,
+   B::LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.AbstractRotation}) =
+   throw("AbstractRotation lacks size so * is unsupported")
+#Base.:(*)(A::Given, B::LinearMapAM) = M_AM(A, B)
 
 Base.:(*)(x::LinearAlgebra.AdjointAbsVec, A::LinearMapAM) = (A' * x')'
 Base.:(*)(x::LinearAlgebra.TransposeAbsVec, A::LinearMapAM) =

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -5,3 +5,4 @@ This may be a bit of a whack-a-mole™ exercise...
 =#
 
 Base.(*)(A::LinearAlgebra.AbstractTriangular, B::LinearMapAM) = M_AM(A, B)
+Base.(*)(transA::LinearAlgebra.Transpose, B::LinearMapAM) = M_AM(transA, B)

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -4,5 +4,22 @@ Avoiding method ambiguities
 This may be a bit of a whack-a-mole™ exercise...
 =#
 
-Base.(*)(A::LinearAlgebra.AbstractTriangular, B::LinearMapAM) = M_AM(A, B)
-Base.(*)(transA::LinearAlgebra.Transpose, B::LinearMapAM) = M_AM(transA, B)
+import LinearAlgebra
+
+const Trans = LinearAlgebra.Transpose{<: Any, <: LinearAlgebra.RealHermSymComplexSym}
+const Adjoi = LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.RealHermSymComplexHerm}
+const Given = LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.AbstractRotation}
+
+Base.:(*)(A::LinearMapAM, D::LinearAlgebra.Diagonal) = AM_M(A, D)
+Base.:(*)(D::LinearAlgebra.Diagonal, B::LinearMapAM,) = M_AM(D, B)
+Base.:(*)(A::LinearMapAM, B::LinearAlgebra.AbstractTriangular) = AM_M(A, B)
+Base.:(*)(A::LinearAlgebra.AbstractTriangular, B::LinearMapAM) = M_AM(A, B)
+Base.:(*)(A::LinearMapAM, B::Trans) = AM_M(A, B)
+Base.:(*)(A::Trans, B::LinearMapAM) = M_AM(A, B)
+Base.:(*)(A::LinearMapAM, B::Adjoi) = AM_M(A, B)
+Base.:(*)(A::Adjoi, B::LinearMapAM) = M_AM(A, B)
+Base.:(*)(A::LinearMapAM, B::Given) = AM_M(A, B)
+Base.:(*)(A::Given, B::LinearMapAM) = M_AM(A, B)
+
+Base.:(*)(x::LinearAlgebra.AdjointAbsVec, A::LinearMapAM) = (A'*x')'
+Base.:(*)(x::LinearAlgebra.TransposeAbsVec, A::LinearMapAM) = transpose(transpose(A)*transpose(x))

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -12,12 +12,16 @@ const Given = LinearAlgebra.Adjoint{<: Any, <: LinearAlgebra.AbstractRotation}
 
 Base.:(*)(A::LinearMapAM, D::LinearAlgebra.Diagonal) = AM_M(A, D)
 Base.:(*)(D::LinearAlgebra.Diagonal, B::LinearMapAM,) = M_AM(D, B)
+
 Base.:(*)(A::LinearMapAM, B::LinearAlgebra.AbstractTriangular) = AM_M(A, B)
 Base.:(*)(A::LinearAlgebra.AbstractTriangular, B::LinearMapAM) = M_AM(A, B)
+
 Base.:(*)(A::LinearMapAM, B::Trans) = AM_M(A, B)
 Base.:(*)(A::Trans, B::LinearMapAM) = M_AM(A, B)
+
 Base.:(*)(A::LinearMapAM, B::Adjoi) = AM_M(A, B)
 Base.:(*)(A::Adjoi, B::LinearMapAM) = M_AM(A, B)
+
 Base.:(*)(A::LinearMapAM, B::Given) = AM_M(A, B)
 Base.:(*)(A::Given, B::LinearMapAM) = M_AM(A, B)
 

--- a/src/ambiguity.jl
+++ b/src/ambiguity.jl
@@ -25,5 +25,6 @@ Base.:(*)(A::Adjoi, B::LinearMapAM) = M_AM(A, B)
 Base.:(*)(A::LinearMapAM, B::Given) = AM_M(A, B)
 Base.:(*)(A::Given, B::LinearMapAM) = M_AM(A, B)
 
-Base.:(*)(x::LinearAlgebra.AdjointAbsVec, A::LinearMapAM) = (A'*x')'
-Base.:(*)(x::LinearAlgebra.TransposeAbsVec, A::LinearMapAM) = transpose(transpose(A)*transpose(x))
+Base.:(*)(x::LinearAlgebra.AdjointAbsVec, A::LinearMapAM) = (A' * x')'
+Base.:(*)(x::LinearAlgebra.TransposeAbsVec, A::LinearMapAM) =
+    transpose(transpose(A) * transpose(x))

--- a/src/kron.jl
+++ b/src/kron.jl
@@ -27,6 +27,14 @@ Base.kron(A::LinearMapAM, M::AbstractMatrix) =
 Base.kron(M::AbstractMatrix, A::LinearMapAM) =
     LinearMapAA(kron(M, A._lmap), A._prop)
 
+
+Base.kron(A::LinearMapAM, D::Diagonal{<: Number}) =
+    LinearMapAA(kron(A._lmap, D), A._prop)
+
+Base.kron(D::Diagonal{<: Number}, A::LinearMapAM) =
+    LinearMapAA(kron(D, A._lmap), A._prop)
+
+
 Base.kron(A::LinearMapAM, B::LinearMapAM) =
     LinearMapAA(kron(A._lmap, B._lmap) ;
         prop = (kron=nothing, props=(A._prop, B._prop)),
@@ -38,6 +46,7 @@ Base.kron(A::LinearMapAO, B::LinearMapAO) =
         odim = (B._odim..., A._odim...),
         idim = (B._idim..., A._idim...),
     )
+
 
 Base.kron(M::AbstractMatrix, A::LinearMapAO) =
     LinearMapAA(kron(M, A._lmap) ; prop = A._prop,

--- a/src/multiply.jl
+++ b/src/multiply.jl
@@ -50,14 +50,16 @@ end
 # multiply with a matrix
 # subtle: AM * Matrix and Matrix * AM yield a new AM
 # whereas AO * M and M * AO yield a matrix of numbers!
-function Base.:(*)(A::LinearMapAM, B::AbstractMatrix)
+function AM_M(A::LinearMapAM, B::AbstractMatrix)
     (A._idim == (size(B,1),)) || throw("$(A._idim) * $(size(B,1)) mismatch")
     LinearMapAA(A._lmap * LinearMap(B) ; prop=A._prop, odim=A._odim)
 end
-function Base.:(*)(A::AbstractMatrix, B::LinearMapAM)
+function M_AM(A::AbstractMatrix, B::LinearMapAM)
     (B._odim == (size(A,2),)) || throw("$(B._odim) * $(size(A,1)) mismatch")
     LinearMapAA(LinearMap(A) * B._lmap ; prop=B._prop, idim=B._idim)
 end
+Base.:(*)(A::LinearMapAM, B::AbstractMatrix) = AM_M(A, B)
+Base.:(*)(A::AbstractMatrix, B::LinearMapAM) = M_AM(A, B)
 
 
 # LMAM case is easy!

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -4,15 +4,17 @@
 using LinearAlgebra: Diagonal, UpperTriangular
 using LinearAlgebra: Adjoint, Transpose, Symmetric
 using LinearAlgebra: TransposeAbsVec, AdjointAbsVec
+using LinearAlgebra: givens
 import LinearAlgebra
 using LinearMapsAA
-using Test: @test, @testset
+using Test: @test, @testset, @test_throws
 
-M = rand(3,3)
+
+M = rand(2,2)
 A = LinearMapAA(M)
 
 @testset "Diagonal" begin
-    D = Diagonal(1:3)
+    D = Diagonal(1:2)
     @test Matrix(A * D) == M * D
     @test Matrix(D * A) == D * M
 end
@@ -24,13 +26,13 @@ end
 end
 
 @testset "TransposeVec" begin
-    xt = Transpose(1:3)
+    xt = Transpose(1:2)
     @test xt isa TransposeAbsVec
     @test xt * M == xt * A
 end
 
 @testset "AdjointVec" begin
-    r = Adjoint(1:3)
+    r = Adjoint(1:2)
     @test r isa AdjointAbsVec
     @test r * M == r * A
 end
@@ -46,10 +48,20 @@ end
 end
 
 @testset "Adjoint" begin
-    C = rand(ComplexF32, 3, 3)
+    C = rand(ComplexF32, 2, 2)
     H = LinearAlgebra.Hermitian(C)
     J = Adjoint(H)
     LinearAlgebra.isposdef(A::Adjoint) = LinearAlgebra.isposdef(parent(A))
     @test Matrix(A * J) == M * J
     @test Matrix(J * A) == J * M
+end
+
+@testset "AbsRot" begin
+    G, _ = givens(1., 2., 3, 4)
+    R = LinearAlgebra.Rotation([G, G])
+    AR = adjoint(R); # semicolon needed, otherwise "show" error!
+    # size(AR) # fails because AR is size-less and not an AbstractMatrix
+    AR isa Adjoint{<:Any,<:LinearAlgebra.AbstractRotation} # true
+    # ones(4,4) * AR # works
+    @test_throws String A * AR
 end

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -38,7 +38,7 @@ end
 @testset "Transpose" begin
 # work-around per
 # https://github.com/Jutho/LinearMaps.jl/issues/147
-    LinearAlgebra.isposdef(A::Transpose{Float64, Symmetric{Float64, Matrix{Float64}}}) = false
+    LinearAlgebra.isposdef(A::Transpose) = LinearAlgebra.isposdef(parent(A))
     S = LinearAlgebra.Symmetric(M)
     T = LinearAlgebra.Transpose(S)
     @test Matrix(A * T) == M * T # failed prior to isposdef overload
@@ -49,9 +49,7 @@ end
     C = rand(ComplexF32, 3, 3)
     H = LinearAlgebra.Hermitian(C)
     J = Adjoint(H)
-    T = typeof(J) # Adjoint{ComplexF32, LinearAlgebra.Hermitian{ComplexF32, Matrix{ComplexF32}}}
-    LinearAlgebra.isposdef(A::T) = false # kludge
-
+    LinearAlgebra.isposdef(A::Adjoint) = LinearAlgebra.isposdef(parent(A))
     @test Matrix(A * J) == M * J
     @test Matrix(J * A) == J * M
 end

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -1,0 +1,34 @@
+# ambiguity.jl
+# tests needed only because of code added to resolve method ambiguities
+
+using LinearAlgebra: Diagonal, UpperTriangular #, symmetric
+using LinearMapsAA
+using Test: @test, @testset
+
+@testset "Diagonal" begin
+	M = rand(3,3)
+	A = LinearMapAA(M)
+
+	D = Diagonal(1:3)
+	@test Matrix(A * D) == M * D
+	@test Matrix(D * A) == D * M
+
+	U = UpperTriangular(M)
+	@test Matrix(A * U) == M * U
+	@test Matrix(U * A) == U * M
+end
+
+#=
+	C = rand(ComplexF32, 3, 3)
+	H = LinearAlgebra.Hermitian(C)
+	J = Adjoint(H)
+
+#	@test Matrix(A * J) == M * J # todo
+#	@test Matrix(J * A) == J * M
+
+	S = LinearAlgebra.Symmetric(M)
+	T = LinearAlgebra.Transpose(S)
+	M * T
+#	A * T # fails - todo
+# https://github.com/Jutho/LinearMaps.jl/issues/147
+=#

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -1,34 +1,50 @@
 # ambiguity.jl
 # tests needed only because of code added to resolve method ambiguities
 
-using LinearAlgebra: Diagonal, UpperTriangular #, symmetric
+using LinearAlgebra: Diagonal, UpperTriangular
+using LinearAlgebra: Adjoint, Transpose #, symmetric
+using LinearAlgebra: TransposeAbsVec, AdjointAbsVec
 using LinearMapsAA
 using Test: @test, @testset
 
+M = rand(3,3)
+A = LinearMapAA(M)
+
 @testset "Diagonal" begin
-	M = rand(3,3)
-	A = LinearMapAA(M)
+    D = Diagonal(1:3)
+    @test Matrix(A * D) == M * D
+    @test Matrix(D * A) == D * M
+end
 
-	D = Diagonal(1:3)
-	@test Matrix(A * D) == M * D
-	@test Matrix(D * A) == D * M
+@testset "UpperTri" begin
+    U = UpperTriangular(M)
+    @test Matrix(A * U) == M * U
+    @test Matrix(U * A) == U * M
+end
 
-	U = UpperTriangular(M)
-	@test Matrix(A * U) == M * U
-	@test Matrix(U * A) == U * M
+@testset "TransposeVec" begin
+    xt = Transpose(1:3)
+    @test xt isa TransposeAbsVec
+    @test xt * M == xt * A
+end
+
+@testset "AdjointVec" begin
+    r = Adjoint(1:3)
+    @test r isa AdjointAbsVec
+    @test r * M == r * A
 end
 
 #=
-	C = rand(ComplexF32, 3, 3)
-	H = LinearAlgebra.Hermitian(C)
-	J = Adjoint(H)
+    C = rand(ComplexF32, 3, 3)
+    H = LinearAlgebra.Hermitian(C)
+    J = Adjoint(H)
 
-#	@test Matrix(A * J) == M * J # todo
-#	@test Matrix(J * A) == J * M
+#   @test Matrix(A * J) == M * J # todo
+#   @test Matrix(J * A) == J * M
 
-	S = LinearAlgebra.Symmetric(M)
-	T = LinearAlgebra.Transpose(S)
-	M * T
-#	A * T # fails - todo
+    S = LinearAlgebra.Symmetric(M)
+    T = LinearAlgebra.Transpose(S)
+    M * T
+#   A * T # fails - todo
 # https://github.com/Jutho/LinearMaps.jl/issues/147
 =#

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@ using Test: @test, @testset, detect_ambiguities
 include("multiply.jl")
 
 list = [
+"ambiguity"
 "identity"
 "kron"
 "cat"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -17,11 +17,11 @@ list = [
 ]
 
 for file in list
-	@testset "$file" begin
-		include("$file.jl")
-	end
+    @testset "$file" begin
+        include("$file.jl")
+    end
 end
 
-if VERSION <= v"1.5.3" # todo: errors in "nightly"
-	@test length(detect_ambiguities(LinearMapsAA)) == 0
+@testset "ambiguities" begin
+    @test length(detect_ambiguities(LinearMapsAA)) == 0
 end


### PR DESCRIPTION
It seems that having `LinearMapAM` be a subtype of `AbstractMatrix` requires care to avoid these ambiguities.
This will probably lead to decreased code coverage so more tests will be needed...
