### PR TITLE
Concise `show` for the property

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMapsAA"
 uuid = "599c1a8e-b958-11e9-0d14-b1e6b2ecea07"
 authors = ["fessler <fessler@umich.edu>"]
-version = "0.7"
+version = "0.7.1"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"

--- a/src/lm-aa.jl
+++ b/src/lm-aa.jl
@@ -31,21 +31,17 @@ Base.ndims(A::LinearMapAO) = ndims(A._lmap) # 2
 Pretty printing for `display`
 """
 function Base.show(io::IO, A::LinearMapAX) # short version
-	print(io, isa(A, LinearMapAM) ? "LinearMapAM" : "LinearMapAO")
-	print(io, ": $(size(A,1)) × $(size(A,2))")
+    print(io, isa(A, LinearMapAM) ? "LinearMapAM" : "LinearMapAO",
+        ": $(size(A,1)) × $(size(A,2))")
 end
 
 # multi-line version:
-Base.show(io::IO, ::MIME"text/plain", A::LinearMapAX{T,Do,Di}) where {T,Do,Di} =
-	begin
-		show(io, A)
-		(A._prop != NamedTuple()) && print(io, "\n$(A._prop)")
-		print(io, "\nodim=$(A._odim) idim=$(A._idim) T=$T Do=$Do Di=$Di")
-	#	print(io, "\n$(A._lmap)\n") # todo: hide until "show" fixed for LM
-		print(io, "\n$(typeof(A._lmap)) ...\n")
-	#	tmp = "$(A._lmap)"[1:77]
-	#	print(io, " $tmp ..")
-	end
+function Base.show(io::IO, ::MIME"text/plain", A::LinearMapAX{T,Do,Di}) where {T,Do,Di}
+    show(io, A)
+    print(io, " odim=$(A._odim) idim=$(A._idim) T=$T Do=$Do Di=$Di")
+    (A._prop != NamedTuple()) && (print(io, "\nprop = "); show(io, A._prop))
+    print(io, "\nmap = $(A._lmap)\n")
+end
 
 # size
 Base.size(A::LinearMapAX) = size(A._lmap)

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -12,6 +12,10 @@ using Test: @test, @testset, @test_throws
 B = reshape(1:6, 6, 1)
 @test Matrix(LinearMapAA(B)) == B
 
+# ensure that "show" is concise even for big `prop`
+L = LinearMapAA(LinearMap(ones(3,4)), (a=1:3, b=ones(99,99)))
+show(isinteractive() ? stdout : devnull, L)
+
 N = 6; M = N+1 # non-square to stress test
 forw = x -> [cumsum(x); 0]
 back = y -> reverse(cumsum(reverse(y[1:N])))


### PR DESCRIPTION
The NamedTuple `A._prop` can have a lot stuff in it, so be concise.