### PR TITLE
Refer `getindex` to `LinearMaps` and restrict to slicing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "LinearMapsAA"
 uuid = "599c1a8e-b958-11e9-0d14-b1e6b2ecea07"
 authors = ["fessler <fessler@umich.edu>"]
-version = "0.10.0"
+version = "0.11.0"
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -11,6 +11,6 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-LinearMaps = "3"
+LinearMaps = "3.7"
 Requires = "1.2"
 julia = "1.6"

--- a/README.md
+++ b/README.md
@@ -237,6 +237,12 @@ partial `getindex` support,
 was added in
 [v3.7](https://github.com/JuliaLinearAlgebra/LinearMaps.jl/releases/tag/v3.7.0)
 there.
+As of v0.11,
+this package uses that `getindex` implementation
+and also supports only slicing.
+This is a breaking change that could be easily reverted,
+so please submit an issue if you have a use case
+for more general use of `getindex`.
 
 
 ## Historical note about `setindex!`

--- a/README.md
+++ b/README.md
@@ -31,13 +31,6 @@ type.
 
 - The package was developed in Ann Arbor, Michigan :)
 
-An `AbstractArray`
-must support a `getindex` operation.
-The maintainers of the `LinearMaps.jl` package
-[have not wished to add getindex there](https://github.com/Jutho/LinearMaps.jl/issues/38),
-so this package adds that feature
-(without committing "type piracy").
-
 As of `v0.6`,
 the package produces objects of two types:
 * `LinearMapAM` (think "Matrix") that is a subtype of `AbstractMatrix`.
@@ -228,6 +221,22 @@ The safe bet is to use all
 or all
 `LinearMapAO` objects
 rather than trying to mix and match.
+
+
+## Historical note about `getindex`
+
+An `AbstractArray`
+must support a `getindex` operation.
+The maintainers of the `LinearMaps.jl` package
+[originally did not wish to add `getindex` there](https://github.com/Jutho/LinearMaps.jl/issues/38),
+so this package added that feature
+(while avoiding "type piracy").
+Eventually,
+partial `getindex` support,
+[specifically slicing](https://github.com/JuliaLinearAlgebra/LinearMaps.jl/pull/165),
+was added in
+[v3.7](https://github.com/JuliaLinearAlgebra/LinearMaps.jl/releases/tag/v3.7.0)
+there.
 
 
 ## Historical note about `setindex!`

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -4,6 +4,7 @@ Indexing support for LinearMapAX
 2018-01-19, Jeff Fessler, University of Michigan
 =#
 
+# As of v0.11, rely on getindex of LM, including its restrictions to slicing
 Base.getindex(A::LinearMapAX, args...) = Base.getindex(A._lmap, args...)
 
 #=

--- a/src/getindex.jl
+++ b/src/getindex.jl
@@ -4,6 +4,9 @@ Indexing support for LinearMapAX
 2018-01-19, Jeff Fessler, University of Michigan
 =#
 
+Base.getindex(A::LinearMapAX, args...) = Base.getindex(A._lmap, args...)
+
+#=
 
 # [end]
 function Base.lastindex(A::LinearMapAX)
@@ -50,7 +53,7 @@ Base.getindex(A::LinearMapAX, ::Colon, jj::Indexer) =
 # trick: cannot use A' for a FunctionMap with no fc
 function Base.getindex(A::LinearMapAX, ii::Indexer, ::Colon)
     if (:fc in propertynames(A._lmap)) && isnothing(A._lmap.fc)
-        return hcat([A[ii,j] for j in 1:size(A,2)]...)
+        return hcat([A[ii,j] for j in 1:size(A,2)]...) # very slow!
     else
         return A'[:,ii]'
     end
@@ -78,3 +81,5 @@ Base.getindex(A::LinearMapAX, ::Colon, ::Colon) = Matrix(A._lmap)
 
 # A[:]
 Base.getindex(A::LinearMapAX, ::Colon) = A[:,:][:]
+
+=#

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -44,7 +44,7 @@ end
     S = LinearAlgebra.Symmetric(M)
     T = LinearAlgebra.Transpose(S)
     @test Matrix(A * T) == M * T # failed prior to isposdef overload
-    @test Matrix(T * A) == T * M
+    @test Matrix(T * A) ≈ T * M
 end
 
 @testset "Adjoint" begin

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -21,20 +21,20 @@ end
 
 @testset "UpperTri" begin
     U = UpperTriangular(M)
-    @test Matrix(A * U) == M * U
-    @test Matrix(U * A) == U * M
+    @test Matrix(A * U) ≈ M * U
+    @test Matrix(U * A) ≈ U * M
 end
 
 @testset "TransposeVec" begin
     xt = Transpose(1:2)
     @test xt isa TransposeAbsVec
-    @test xt * M == xt * A
+    @test xt * M ≈ xt * A
 end
 
 @testset "AdjointVec" begin
     r = Adjoint(1:2)
     @test r isa AdjointAbsVec
-    @test r * M == r * A
+    @test r * M ≈ r * A
 end
 
 @testset "Transpose" begin
@@ -43,7 +43,7 @@ end
     LinearAlgebra.isposdef(A::Transpose) = LinearAlgebra.isposdef(parent(A))
     S = LinearAlgebra.Symmetric(M)
     T = LinearAlgebra.Transpose(S)
-    @test Matrix(A * T) == M * T # failed prior to isposdef overload
+    @test Matrix(A * T) ≈ M * T # failed prior to isposdef overload
     @test Matrix(T * A) ≈ T * M
 end
 
@@ -52,8 +52,8 @@ end
     H = LinearAlgebra.Hermitian(C)
     J = Adjoint(H)
     LinearAlgebra.isposdef(A::Adjoint) = LinearAlgebra.isposdef(parent(A))
-    @test Matrix(A * J) == M * J
-    @test Matrix(J * A) == J * M
+    @test Matrix(A * J) ≈ M * J
+    @test Matrix(J * A) ≈ J * M
 end
 
 @testset "AbsRot" begin

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -2,13 +2,11 @@
 # test
 
 using LinearMapsAA: LinearMapAA, LinearMapAX
-using Test: @test, @testset
+using Test: @test, @test_throws, @testset
 
-# only slicing supported as of LM 3.7 !
-_slice(a::Colon, b::Int) = true
-_slice(a::Int, b::Colon) = true
-_slice(a::Colon, b::Colon) = true
-_slice(a::Any, b::Any) = false
+
+_slice(a, b) = (a == :) || (b == :) # only slicing supported as of LM 3.7 !
+
 
 """
     LinearMapAA_test_getindex(A::LinearMapAX)
@@ -25,6 +23,8 @@ function LinearMapAA_test_getindex(A::LinearMapAX)
     for i2 in ii2, i1 in ii1
         if _slice(i1, i2)
             @test B[i1,i2] == A[i1,i2]
+        else
+            @test_throws ErrorException B[i1,i2] == A[i1,i2]
         end
     end
 
@@ -34,6 +34,8 @@ function LinearMapAA_test_getindex(A::LinearMapAX)
         for i1 in ii2, i2 in ii1
             if _slice(i1, i2)
                 @test B'[i1,i2] == A'[i1,i2]
+            else
+                @test_throws ErrorException B'[i1,i2] == A'[i1,i2]
             end
         end
     end

--- a/test/getindex.jl
+++ b/test/getindex.jl
@@ -4,6 +4,11 @@
 using LinearMapsAA: LinearMapAA, LinearMapAX
 using Test: @test, @testset
 
+# only slicing supported as of LM 3.7 !
+_slice(a::Colon, b::Int) = true
+_slice(a::Int, b::Colon) = true
+_slice(a::Colon, b::Colon) = true
+_slice(a::Any, b::Any) = false
 
 """
     LinearMapAA_test_getindex(A::LinearMapAX)
@@ -17,8 +22,8 @@ function LinearMapAA_test_getindex(A::LinearMapAX)
     tf2 = [false; trues(size(A,2)-2); false]
     ii1 = (3, 2:4, [2,4], :, tf1)
     ii2 = (2, 3:4, [1,4], :, tf2)
-    for i2 in ii2
-        for i1 in ii1
+    for i2 in ii2, i1 in ii1
+        if _slice(i1, i2)
             @test B[i1,i2] == A[i1,i2]
         end
     end
@@ -26,13 +31,17 @@ function LinearMapAA_test_getindex(A::LinearMapAX)
     L = A._lmap
     test_adj = !((:fc in propertynames(L)) && isnothing(L.fc))
     if test_adj
-        for i1 in ii2
-            for i2 in ii1
+        for i1 in ii2, i2 in ii1
+            if _slice(i1, i2)
                 @test B'[i1,i2] == A'[i1,i2]
             end
         end
     end
+    true
+end
 
+
+function LinearMapAA_test_getindex_scalar(A::LinearMapAX)
     # "end"
     @test B[3,end-1] == A[3,end-1]
     @test B[end-2,3] == A[end-2,3]
@@ -51,7 +60,7 @@ function LinearMapAA_test_getindex(A::LinearMapAX)
     kk = [k in [3,5] for k = 1:length(A)] # Bool
     @test B[kk] == A[kk]
 
-    # Some tests could rely on the fact that LinearMapAM <:i AbstractMatrix,
+    # Some tests could rely on the fact that LinearMapAM <: AbstractMatrix,
     # by inheriting from general Base.getindex, but all are provided here.
     @test B[[1, 3, 4]] == A[[1, 3, 4]]
     @test B[4:7] == A[4:7]
@@ -65,3 +74,4 @@ forw = x -> [cumsum(x); 0; 0]
 back = y -> reverse(cumsum(reverse(y[1:N])))
 A = LinearMapAA(forw, back, (M, N))
 @test LinearMapAA_test_getindex(A)
+# @test LinearMapAA_test_getindex_scalar(A) # no!

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -160,7 +160,7 @@ end
 end
 
 # non-adjoint version
-#= todo: probably not worth supporting anymore
+#= no longer supported, for consistency with LM
 @testset "non-adjoint" begin
     Af = LinearMapAA(forw, (M, N))
     @test Matrix(Af) == Lm

--- a/test/tests.jl
+++ b/test/tests.jl
@@ -160,12 +160,14 @@ end
 end
 
 # non-adjoint version
+#= todo: probably not worth supporting anymore
 @testset "non-adjoint" begin
     Af = LinearMapAA(forw, (M, N))
     @test Matrix(Af) == Lm
     @test LinearMapAA_test_getindex(Af)
 #   @test LinearMapAA_test_setindex(Af)
 end
+=#
 
 @testset "AO for 1D" begin
     B = LinearMapAO(A)


### PR DESCRIPTION
Some `getindex` features have now been added to LinearMaps: https://github.com/JuliaLinearAlgebra/LinearMaps.jl/pull/165

After at lot of discussion there, it was decided to support only slicing, like `A[:,j]` and to throw an error for (very inefficient) scalar indexing like `A[i,j]` and `A[k]`.  This PR propagates those policies to this repo as well.

This is a highly breaking change because previously this repo supported every possible type of `getindex`, in the spirit of a proper `AbstractArray`.  However, scalar indexing really is very inefficient and unlikely to be used so for now I am "going with the flow" and adopting consistency with LM.  In the unlikely event there are some users who really need scalar indexing, I will consider reverting.

Curiously, I had to replace some `==` with `\approx` for the tests to pass.

Another big change is eliminating support (and tests) for `A[:,j]` for maps that do not have a backward mapping function, again for consistency with LM.  It seems best to eliminate that anyway because it was very slow, so not supporting it may force users to think about providing the adjoint function!