### PR TITLE
Add CUDA (non)testing message

### DIFF
--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -55,4 +55,5 @@ if CUDA.functional()
     @test xa == vec(xo)
 else
     @warn "no CUDA test"
+    @info "One must test CUDA separately"
 end

--- a/test/cuda.jl
+++ b/test/cuda.jl
@@ -8,7 +8,7 @@ import CUDA
 using Test: @test
 
 if CUDA.functional()
-    isinteractive() && @info "testing CUDA"
+    @info "testing CUDA"
     CUDA.allowscalar(false)
 
     nx, ny, nz = 5, 7, 6
@@ -53,4 +53,6 @@ if CUDA.functional()
     xa = A' * vec(yo)
     @test xl == vec(xo)
     @test xa == vec(xo)
+else
+    @warn "no CUDA test"
 end


### PR DESCRIPTION
To remind me (and others) that sadly there is no GPU test in github CI, so we must run CUDA-related tests separately.

https://discourse.julialang.org/t/how-to-use-cuda-in-github-ci/77855

This also tested whether `@info` and `@warn` show in the CI logs (both do).
