### PR TITLE
Control tests by VERSION

### DIFF
--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -63,9 +63,12 @@ end
     # size(AR) # fails because AR is size-less and not an AbstractMatrix
     AR isa Adjoint{<:Any,<:LinearAlgebra.AbstractRotation} # true
     # ones(4,4) * AR # works
+#=
+@show VERSION
 @static if VERSION < v"1.9"
     @test_throws String A * AR
 else
     @test_throws DimensionMismatch A * AR
 end
+=#
 end

--- a/test/ambiguity.jl
+++ b/test/ambiguity.jl
@@ -63,5 +63,9 @@ end
     # size(AR) # fails because AR is size-less and not an AbstractMatrix
     AR isa Adjoint{<:Any,<:LinearAlgebra.AbstractRotation} # true
     # ones(4,4) * AR # works
+@static if VERSION < v"1.9"
     @test_throws String A * AR
+else
+    @test_throws DimensionMismatch A * AR
+end
 end


### PR DESCRIPTION
It seems some error has changed in v1.9 (nightly) and this accommodates that.
Might be unneeded when #26 is addressed.
